### PR TITLE
[MMP-26839] Update MMP back office order details URL

### DIFF
--- a/Core/Helper/Connection.php
+++ b/Core/Helper/Connection.php
@@ -70,7 +70,7 @@ class Connection extends Data
     public function getMiraklOrderUrl(Model $connection, MiraklOrder $miraklOrder)
     {
         $url = sprintf(
-            '%s/mmp/shop/order/%s/information',
+            '%s/mmp/shop/order/%s',
             $connection->getBaseUrl(),
             $miraklOrder->getId()
         );


### PR DESCRIPTION
In MMP, back office order details URL is now `/mmp/(shop|operator)/order/{orderUuid}`. This URL ending with `/information` is deprecated and will be deleted soon (`/mmp/(shop|operator)/order/{orderUuid}/information`).